### PR TITLE
docs(readme): small fix for broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Although this isn't a library, we recently started versioning to make it easier 
 
 I am more than happy to accept external contributions to the project in the form of feedback, bug reports and even better - pull requests :) 
 
-If you would like to submit a pull request, please make an effort to follow the guide in [CONTRIBUTING.md](contributing.md). 
+If you would like to submit a pull request, please make an effort to follow the guide in [CONTRIBUTING.md](CONTRIBUTING.md). 
  
 ---
 Thanks for checking this out.


### PR DESCRIPTION
fixes casing on link to contributing guide

as an aside, this is kinda cool: github's PR interface recognizes we have a contributing guide and encourages reading it before submitting the PR... check it out

![image](https://cloud.githubusercontent.com/assets/1539088/11094689/1a4489a8-885f-11e5-9f94-a4c6823d4488.png)

i had no idea about that feature